### PR TITLE
Add nullcheck for assets

### DIFF
--- a/dist/WebpackPwaManifest.js
+++ b/dist/WebpackPwaManifest.js
@@ -52,6 +52,11 @@ var WebpackPwaManifest = function () {
         });
       });
       compiler.plugin('emit', function (compilation, callback) {
+        if (!_this.assets) {
+          callback();
+          return;
+        }
+
         var _loop = function _loop(asset) {
           compilation.assets[asset.file] = {
             source: function source() {

--- a/src/WebpackPwaManifest.js
+++ b/src/WebpackPwaManifest.js
@@ -34,6 +34,11 @@ class WebpackPwaManifest {
       })
     })
     compiler.plugin('emit', (compilation, callback) => {
+      if (!_this.assets) {
+        callback()
+        return
+      }
+
       for (let asset of _this.assets) {
         compilation.assets[asset.file] = {
           source: () => asset.source,


### PR DESCRIPTION
I haven't looked too much into the why behind this, but it looks like this happens when `icons` is not set.