### PR TITLE
Default file to path independent

### DIFF
--- a/src/WebpackPwaManifest.js
+++ b/src/WebpackPwaManifest.js
@@ -8,7 +8,7 @@ class WebpackPwaManifest {
     validatePresets(options, 'dir', 'display', 'orientation')
     validateColors(options, 'background_color', 'theme_color')
     this.options = Object.assign({
-      filename: 'manifest.json',
+      filename: '/manifest.json',
       name: 'App',
       orientation: 'portrait',
       display: 'standalone',


### PR DESCRIPTION
Currently the injected html has:

```html
<link rel="manifest" href="manifest.74c47a865b74c433aeb61b3c792620c0.json" />
```

This will load `/some-page/manifest.74c47a865b74c433aeb61b3c792620c0.json` if you are on `/some-page`.
This change defaults to requesting `/manifest.74c47a865b74c433aeb61b3c792620c0.json` on any page.  I like it just being the default so the user can configure still if they desire (for some reason) to leave out the slash