### PR TITLE
Fix dir of the filename not being preserved

### DIFF
--- a/dist/Injector.js
+++ b/dist/Injector.js
@@ -48,7 +48,7 @@ function manifest(options, publicPath, icons, callback) {
   delete content.ios;
   var json = JSON.stringify(content, null, 2);
   var filename = _path2.default.parse(options.filename);
-  var output = options.fingerprints ? filename.name + '.' + (0, _Fingerprint2.default)(json) + filename.ext : '' + filename.name + filename.ext;
+  var output = _path2.default.join(filename.dir, options.fingerprints ? filename.name + '.' + (0, _Fingerprint2.default)(json) + filename.ext : '' + filename.name + filename.ext);
   callback(null, {
     output: output,
     file: (0, _URI.joinURI)(publicPath, output),

--- a/src/Injector.js
+++ b/src/Injector.js
@@ -38,7 +38,10 @@ function manifest (options, publicPath, icons, callback) {
   delete content.ios
   const json = JSON.stringify(content, null, 2)
   const filename = path.parse(options.filename)
-  const output = options.fingerprints ? `${filename.name}.${generateFingerprint(json)}${filename.ext}` : `${filename.name}${filename.ext}`
+  const output = path.join(
+      filename.dir,
+      options.fingerprints ? `${filename.name}.${generateFingerprint(json)}${filename.ext}` : `${filename.name}${filename.ext}`
+  )
   callback(null, {
     output,
     file: joinURI(publicPath, output),


### PR DESCRIPTION
Fixes #28 

With this change, if `filename` is `foo/manifest.json`, the `manifest.json` file will be created inside `foo`.

Do not merge yet, @paulobmarcos will test it out manually since there's no unit tests for this package 😢 