### PR TITLE
Fix manifest fingerprint hash in basic test

### DIFF
--- a/src/injector/index.js
+++ b/src/injector/index.js
@@ -33,11 +33,10 @@ const appleTags = {
 
 function createFilename (filenameTemplate, json) {
   const formatters = [{
-    pattern: /\[hash(:\d{1,2})?\]/gi,
+    pattern: /\[hash(:([1-9]|[1-2][0-9]|3[0-2]))?\]/gi,
     value: (match, limit = ':32') => {
       const hash = generateFingerprint(json)
-      limit = hash.length - parseInt(limit.substr(1), 10)
-      return hash.substr(0, limit)
+      return hash.substr(0, parseInt(limit.substr(1), 10))
     }
   }, {
     pattern: /\[ext\]/gi,


### PR DESCRIPTION
The basic test is not passing when generating the fingerprint hash for `manifest.json`. 
This PR addresses an issue where the hash length when limited to the generated hash length, the resulting manifest file name would become `manifest..json`. Further, the regex for `[hash:limit]` substitution now only allows a limit between 1 and 32. This was also a problem because the limit could be greater than 32, which would exceed the maximum generated hash length.