### PR TITLE
Add gcm_sender_id prop on ManifestOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare namespace WebpackPwaManifest {
         display?: Display;
         fingerprints?: boolean;
         filename?: string;
+        gcm_sender_id?: string;
         icons?: Icon | Icon[];
         inject?: boolean;
         lang?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ declare namespace WebpackPwaManifest {
         theme_color?: string;
         'theme-color'?: string;
         ios?: boolean | IosOptions;
+        publicPath?: string;
     }
     interface RelatedApplications {
         platform?: string;


### PR DESCRIPTION
Just adding `gcm_sender_id` prop on `ManifestOptions`

related: https://github.com/arthurbergmz/webpack-pwa-manifest/issues/46