### PR TITLE
Add crossorigin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ plugins: [
     short_name: 'MyPWA',
     description: 'My awesome Progressive Web App!',
     background_color: '#ffffff',
-    crossorigin: 'use-credentials', //can be undefined, use-credentials or anonymous
+    crossorigin: 'use-credentials', //can be null, use-credentials or anonymous
     icons: [
       {
         src: path.resolve('src/assets/icon.png'),
@@ -163,9 +163,6 @@ If `publicPath` option is not given, this plugin fallbacks to [Webpack's public 
 
 When defining an icon object, you can also specify its output directory using a property called `destination`. Using `ios: true` in an icon object makes it eligible to the `apple-touch-icon` meta tag injection. Using `ios: 'startup'` in an icon object makes it eligible to the `apple-touch-startup-image` meta tag injection.
 
-If you specify an valid `crossorigin` property it will be added to the manifest link tag in the html. 
-This property determines if the request for the manifest includes CORS headers and is required if the manifest is located on a different domain or requires authentication.
-
 ```javascript
   ...
   icons: [
@@ -189,3 +186,6 @@ This property determines if the request for the manifest includes CORS headers a
   ]
 }
 ```
+
+If you specify a valid `crossorigin` property it will be added to the `<link rel="manifest">` in the HTML document. 
+This property determines if the request for the manifest includes CORS headers and is required if the manifest is located on a different domain or requires authentication.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ plugins: [
     short_name: 'MyPWA',
     description: 'My awesome Progressive Web App!',
     background_color: '#ffffff',
+    crossorigin: 'use-credentials', //can be undefined, use-credentials or anonymous
     icons: [
       {
         src: path.resolve('src/assets/icon.png'),
@@ -132,6 +133,7 @@ Presets of `options`:
   orientation: "portrait",
   display: "standalone",
   start_url: ".",
+  crossorigin: null,
   inject: true,
   fingerprints: true,
   ios: false,
@@ -160,6 +162,9 @@ When `inject: true` and `ios: true`, specific Apple meta tags will be injected t
 If `publicPath` option is not given, this plugin fallbacks to [Webpack's public path](https://webpack.js.org/configuration/output/#output-publicpath) definition.
 
 When defining an icon object, you can also specify its output directory using a property called `destination`. Using `ios: true` in an icon object makes it eligible to the `apple-touch-icon` meta tag injection. Using `ios: 'startup'` in an icon object makes it eligible to the `apple-touch-startup-image` meta tag injection.
+
+If you specify an valid `crossorigin` property it will be added to the manifest link tag in the html. 
+This property determines if the request for the manifest includes CORS headers and is required if the manifest is located on a different domain or requires authentication.
 
 ```javascript
   ...

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare namespace WebpackPwaManifest {
     type Direction = 'ltr' | 'rtl' | 'auto';
     type Display = 'fullscreen' | 'standalone' | 'minimal-ui' | 'browser';
     type Orientation = 'any' | 'natural' | 'landscape' | 'landscape-primary' | 'landscape-secondary' | 'portrait' | 'portrait-primary' | 'portrait-secondary';
+    type CrossOrigin = 'use-credentials' | 'anonymous';
     interface ManifestOptions {
         background_color?: string;
         description?: string;
@@ -35,6 +36,7 @@ declare namespace WebpackPwaManifest {
         theme_color?: string;
         'theme-color'?: string;
         ios?: boolean | IosOptions;
+        crossorigin?: CrossOrigin;
     }
     interface RelatedApplications {
         platform?: string;

--- a/src/generators/legacy.js
+++ b/src/generators/legacy.js
@@ -12,10 +12,10 @@ module.exports = function (that, compiler) {
             content: that.options['theme-color'] || that.options.theme_color
           }
           if (themeColorTag.content) applyTag(tags, 'meta', themeColorTag)
-          applyTag(tags, 'link', {
+          applyTag(tags, 'link', Object.assign({
             rel: 'manifest',
             href: that.manifest.url
-          })
+          }, !!that.options.crossorigin && { crossorigin: that.options.crossorigin }))
           tags = generateMaskIconLink(tags, that.assets)
           htmlPluginData.html = htmlPluginData.html.replace(/(<\/head>)/i, `${generateHtmlTags(tags)}</head>`)
         }

--- a/src/generators/tapable.js
+++ b/src/generators/tapable.js
@@ -13,10 +13,10 @@ module.exports = function (that, { hooks: { compilation: comp, emit } }) {
             content: that.options['theme-color'] || that.options.theme_color
           }
           if (themeColorTag.content) applyTag(tags, 'meta', themeColorTag)
-          applyTag(tags, 'link', {
+          applyTag(tags, 'link', Object.assign({
             rel: 'manifest',
             href: that.manifest.url
-          })
+          }, !!that.options.crossorigin && { crossorigin: that.options.crossorigin }))
           tags = generateMaskIconLink(tags, that.assets)
           htmlPluginData.html = htmlPluginData.html.replace(/(<\/head>)/i, `${generateHtmlTags(tags)}</head>`)
         }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import checkDeprecated from './validators/versioning'
 
 class WebpackPwaManifest {
   constructor (options = {}) {
-    validatePresets(options, 'dir', 'display', 'orientation')
+    validatePresets(options, 'dir', 'display', 'orientation', 'crossorigin')
     validateColors(options, 'background_color', 'theme_color')
     checkDeprecated(options, 'useWebpackPublicPath')
     this._generator = null
@@ -22,7 +22,8 @@ class WebpackPwaManifest {
       fingerprints: true,
       ios: false,
       publicPath: null,
-      includeDirectory: true
+      includeDirectory: true,
+      crossorigin: null
     }, options)
   }
 

--- a/src/injector/index.js
+++ b/src/injector/index.js
@@ -51,7 +51,7 @@ function createFilename (filenameTemplate, json, shouldFingerprint) {
 }
 
 function manifest (options, publicPath, icons, callback) {
-  const content = except(Object.assign({ icons }, options), ['filename', 'inject', 'fingerprints', 'ios', 'publicPath', 'icon', 'useWebpackPublicPath', 'includeDirectory'])
+  const content = except(Object.assign({ icons }, options), ['filename', 'inject', 'fingerprints', 'ios', 'publicPath', 'icon', 'useWebpackPublicPath', 'includeDirectory', 'crossorigin'])
   const json = JSON.stringify(content, null, 2)
   const file = path.parse(options.filename)
   const filename = createFilename(file.base, json, options.fingerprints)

--- a/src/validators/presets.js
+++ b/src/validators/presets.js
@@ -9,6 +9,9 @@ const presets = {
   ],
   display: [
     'fullscreen', 'standalone', 'minimal-ui', 'browser'
+  ],
+  crossorigin: [
+    'anonymous', 'use-credentials'
   ]
 }
 

--- a/tests/basic/build/webpack.config.js
+++ b/tests/basic/build/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
       description: 'My awesome Progressive Web App!',
       background_color: '#ffffff',
       ios: true,
+      crossorigin: 'use-credentials',
       icons: [
         {
           src: path.resolve('./tests/icon.png'),

--- a/tests/basic/build/webpack.config.js
+++ b/tests/basic/build/webpack.config.js
@@ -28,7 +28,6 @@ module.exports = {
       description: 'My awesome Progressive Web App!',
       background_color: '#ffffff',
       ios: true,
-      crossorigin: 'use-credentials',
       icons: [
         {
           src: path.resolve('./tests/icon.png'),

--- a/tests/complex/build/webpack.config.js
+++ b/tests/complex/build/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
       description: 'My awesome Progressive Web App!',
       background_color: '#ffffff',
       ios: true,
+      crossorigin: 'use-credentials',
       icons: [
         {
           src: path.resolve('./tests/icon.png'),


### PR DESCRIPTION
This change adds the crossorigin option which can be undefined, use-credentials or anonymous. 

This fixes the issue were Chrome will not send cookies with the request for the manifest if a crossorigin value of 'use-credentials' is not present.

ps I also changed the tests but i seem to have some problems running them: 

- The package.json requires webpack 4 but the webpack configs are not updated for webpack 4
- The path to ../app.js seems to be wrong
- The output folder is not cleaned before running the tests