### PR TITLE
Fix manifest..json bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ class WebpackPwaManifest {
     this.htmlPlugin = false
     const shortName = options.short_name || options.name || 'App'
     this.options = Object.assign({
-      filename: '[name].[hash][ext]',
+      filename: options.fingerprints ? '[name].[hash].[ext]' : '[name].[ext]',
       name: 'App',
       short_name: shortName,
       orientation: 'portrait',

--- a/src/injector/index.js
+++ b/src/injector/index.js
@@ -41,7 +41,7 @@ function createFilename (filenameTemplate, json, shouldFingerprint) {
     }
   }, {
     pattern: /\[ext\]/gi,
-    value: '.json'
+    value: 'json'
   }, {
     pattern: /\[name\]/gi,
     value: 'manifest'


### PR DESCRIPTION
## What was done

There was a bug: when you set `fingerprints: false` and dont set `filename` → it creates a file with name `manifest..json`.