### PR TITLE
[#55] Add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "package-lock.json",
     "package.json",
     "README.md"
-  ]
+  ],
+  "engines": {
+    "node": ">=6.0.0"
+  }
 }


### PR DESCRIPTION
Generate a warning for users of older nodes, for whom this package does not work due to #55.