### PR TITLE
Feat: Support maskable icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ plugins: [
       {
         src: path.resolve('src/assets/large-icon.png'),
         size: '1024x1024' // you can also use the specifications pattern
+      },
+      {
+        src: path.resolve('src/assets/maskable-icon.png'),
+        size: '1024x1024',
+        purpose: 'maskable'
       }
     ]
   })
@@ -71,6 +76,12 @@ plugins: [
   "description": "My awesome Progressive Web App!",
   "background_color": "#ffffff",
   "icons": [
+    {
+      "src": "icon_1024x1024.<fingerprint>.png",
+      "sizes": "1024x1024",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
     {
       "src": "icon_1024x1024.<fingerprint>.png",
       "sizes": "1024x1024",
@@ -189,5 +200,5 @@ When defining an icon object, you can also specify its output directory using a 
 }
 ```
 
-If you specify a valid `crossorigin` property it will be added to the `<link rel="manifest">` in the HTML document. 
+If you specify a valid `crossorigin` property it will be added to the `<link rel="manifest">` in the HTML document.
 This property determines if the request for the manifest includes CORS headers and is required if the manifest is located on a different domain or requires authentication.

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -22,7 +22,8 @@ function sanitizeIcon (iconSnippet) {
     sizes,
     destination: iconSnippet.destination,
     ios: iconSnippet.ios || false,
-    color: iconSnippet.color
+    color: iconSnippet.color,
+    purpose: iconSnippet.purpose
   }
 }
 
@@ -35,7 +36,8 @@ function processIcon (currentSize, icon, buffer, mimeType, publicPath, shouldFin
     manifestIcon: {
       src: iconPublicUrl,
       sizes: dimensions,
-      type: mimeType
+      type: mimeType,
+      purpose: icon.purpose
     },
     webpackAsset: {
       output: iconOutputDir,


### PR DESCRIPTION
Enables users to pass custom `icons[].purpose` like `'any'` or `'maskable'`. See https://developer.mozilla.org/en-US/docs/Web/Manifest/icons#Values for more info.

![image](https://user-images.githubusercontent.com/1045362/71564333-6fad0c80-2a9f-11ea-9a86-950a222ddc00.png)

Closes #112

### Output example:

![image](https://user-images.githubusercontent.com/1045362/71564324-455b4f00-2a9f-11ea-8574-96959b8e1676.png)
