### PR TITLE
Interpolate `hash` in publicPath

### DIFF
--- a/src/generators/tapable.js
+++ b/src/generators/tapable.js
@@ -21,7 +21,11 @@ module.exports = function (that, { hooks: { compilation: comp, emit } }) {
     if (!beforeProcessingHook) return;
     beforeProcessingHook.tapAsync('webpack-pwa-manifest', function(htmlPluginData, callback) {
       if (!that.htmlPlugin) that.htmlPlugin = true
-      buildResources(that, that.options.publicPath || compilation.options.output.publicPath, () => {
+      const publicPath = compilation.mainTemplate.getAssetPath(
+        that.options.publicPath || compilation.options.output.publicPath,
+        { hash: compilation.hash }
+      );
+      buildResources(that, publicPath, () => {
         if (that.options.inject) {
           let tags = generateAppleTags(that.options, that.assets)
           const themeColorTag = {
@@ -44,7 +48,11 @@ module.exports = function (that, { hooks: { compilation: comp, emit } }) {
     if (that.htmlPlugin) {
       injectResources(compilation, that.assets, callback)
     } else {
-      buildResources(that, that.options.publicPath || compilation.options.output.publicPath, () => {
+      const publicPath = compilation.mainTemplate.getAssetPath(
+        that.options.publicPath || compilation.options.output.publicPath,
+        { hash: compilation.hash }
+      );
+      buildResources(that, publicPath, () => {
         injectResources(compilation, that.assets, callback)
       })
     }


### PR DESCRIPTION
The webpack public path can contain a `[hash]` variable to be interpolated.

HtmlWebpackPlugin interpolates it this way: https://github.com/jantimon/html-webpack-plugin/blob/master/index.js#L560
Using getAssetPath instead we can pass the path and also interpolate the given publicPath: https://github.com/webpack/webpack/blob/v4.42.1/lib/MainTemplate.js#L520-L522