### PR TITLE
Add support for <head>-less templates

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
     "presets": [
-        "@babel/preset-env"
+        ["@babel/preset-env",{
+            "targets": {
+                "node": "6.0.0"
+            }
+        }]
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,15 +1580,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -2148,12 +2139,6 @@
           }
         }
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -3127,18 +3112,6 @@
             "kind-of": "^6.0.2"
           }
         }
-      }
-    },
-    "extract-text-webpack-plugin": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
-      "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
-      "dev": true,
-      "requires": {
-        "async": "^2.4.1",
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.3.0",
-        "webpack-sources": "^1.0.1"
       }
     },
     "fast-deep-equal": {
@@ -6158,41 +6131,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "schema-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-      "dev": true,
-      "requires": {
-        "ajv": "^5.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        }
-      }
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,14 @@
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   },
+  "peerDependencies": {
+    "html-webpack-plugin": ">=3.2.0 || >=4.0.0-alpha.2 <5"
+  },
+  "peerDependenciesMeta": {
+    "html-webpack-plugin": {
+      "optional": true
+    }
+  },
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@babel/preset-env": "^7.8.4",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
-    "extract-text-webpack-plugin": "^3.0.2",
     "html-webpack-plugin": ">=3.2.0",
     "list-directory-contents": "0.0.3",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Hi,

this PR changes the hook used by the tapable generator from `beforeEmit` that modifies the generated HTML to `alterAssetTags`/`alterAssetTagGroups` (depending on the html-webpack-plugin version), that inserts manifest tags into the data structure provided by the html-webpack-plugin.

This makes it possible to use the webpack-pwa-manifest plugin for templates without a `head` tag. Until now that was not possible, because the manifest tags would be inserted before the closing `head` tag through string replacement. The following html-webpack-plugin configuration would produce a `<head>`-less template:

```js
{
  inject: false,
  templateContent ({ htmlWebpackPlugin }) {
    const tags = [].concat(
      htmlWebpackPlugin.tags.headTags,
      htmlWebpackPlugin.tags.bodyTags
    )
    return tags.join('\n')
  }
}
```

This is helpful in scenarios where the generated HTML is loaded into an existing `head` tag. In my case I include the generated HTML into my python-django application via the include mechanism of the template engine.

This PR also changes a few other things. I’m not sure if they should end up in the same pull request, but YMMV:

* removed the unused extract-text-webpack-plugin
* declared html-webpack-plugin as an optional peer dependency (this follows the current setup, though I think it should be non-optional?)
* Bump the babel compilation target to node v6 which aligns with the engine target in the `package.json`. This enables native support for generator functions, which I use in my code.

**NOTE**: I have **not** added tests for this because I’m not sure how to test the behaviour for html-webpack-plugin v4, as v3 is the one installed by dev-dependencies. I can confirm it’s working, because I myself use v4 in my project, but that is more like anecdotal evidence :). Feel free to make a suggestion on how to solve this and I’ll look into it.

Cheers

Konrad