### PR TITLE
🏷 add icon.purpose to d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,5 +60,6 @@ declare namespace WebpackPwaManifest {
         sizes?: number[];
         destination?: string;
         ios?: boolean | 'default' | 'startup';
+        purpose?: string;
     }
 }


### PR DESCRIPTION
I was using the plugin in a typescript project and noticed that the Icon type was missing the purpose property.

https://w3c.github.io/manifest/#purpose-member