### PR TITLE
Allow filtering which file to inject manifest into

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Presets of `options`:
 }
 ```
 
+`inject` accepts a boolean or function to allow filtering the file to inject into. e.g. `(htmlPlugin) => basename(htmlPlugin.options.filename) === 'index.html'`
+
 By default, HTML injection and fingerprint generation are on.
 With `inject: false` and `fingerprints: false`, respectively, you can turn them off.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "build": "npx babel src --out-dir dist",
+    "prepare": "npm run build",
     "clean": "rimraf -rf tests/*/output && rimraf -rf dist",
     "test": "npm run clean && npm run build && node tests/index.js",
     "test:debug": "npm run clean && npm run build && node --inspect-brk ./tests/index.js"

--- a/src/generators/tapable.js
+++ b/src/generators/tapable.js
@@ -22,7 +22,12 @@ module.exports = function (that, { hooks: { compilation: comp, emit } }) {
     beforeProcessingHook.tapAsync('webpack-pwa-manifest', function(htmlPluginData, callback) {
       if (!that.htmlPlugin) that.htmlPlugin = true
       buildResources(that, that.options.publicPath || compilation.options.output.publicPath, () => {
-        if (that.options.inject) {
+        const isInjectionAllowed =
+          typeof that.options.inject === 'function'
+            ? that.options.inject(htmlPluginData.plugin)
+            : that.options.inject
+
+        if (isInjectionAllowed) {
           let tags = generateAppleTags(that.options, that.assets)
           const themeColorTag = {
             name: 'theme-color',


### PR DESCRIPTION
Compiling image assets is tied to the `inject` flag. We have multiple targets with manifest configurations. This allows us to selectively inject and process assets for specific entry points.