### PR TITLE
Allow configuring the JSON.stringify space option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,8 @@ class WebpackPwaManifest {
       ios: false,
       publicPath: null,
       includeDirectory: true,
-      crossorigin: null
+      crossorigin: null,
+      space: 2
     }, options)
   }
 

--- a/src/injector/index.js
+++ b/src/injector/index.js
@@ -51,11 +51,11 @@ function createFilename (filenameTemplate, json, shouldFingerprint) {
 }
 
 function manifest (options, publicPath, icons, callback) {
-  const content = except(Object.assign({ icons }, options), ['filename', 'inject', 'fingerprints', 'ios', 'publicPath', 'icon', 'useWebpackPublicPath', 'includeDirectory', 'crossorigin'])
+  const content = except(Object.assign({ icons }, options), ['filename', 'inject', 'fingerprints', 'ios', 'publicPath', 'icon', 'useWebpackPublicPath', 'includeDirectory', 'crossorigin', 'space'])
   if (options.orientation === 'omit') {
     delete content.orientation
   }
-  const json = JSON.stringify(content, null, 2)
+  const json = JSON.stringify(content, null, options.space)
   const file = path.parse(options.filename)
   const filename = createFilename(file.base, json, options.fingerprints)
   const output = options.includeDirectory ? path.join(file.dir, filename) : filename


### PR DESCRIPTION
This pull request adds the `space` option to the options, which sets the `space` option used for the `JSON.stringify` call. To maintain backwards compatibility, it defaults to `2`. This option is useful for generating minified manifests.