### PR TITLE
types: add apply property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,12 +2,14 @@
 // Project: https://github.com/arthurbergmz/webpack-pwa-manifest
 // Definitions by: Arthur A. Bergamaschi <https://www.github.com/arthurbergmz>
 
-import { Plugin } from 'webpack';
+import { Compiler, Plugin } from 'webpack';
 
 export = WebpackPwaManifest
 
 declare class WebpackPwaManifest extends Plugin {
     constructor(options: WebpackPwaManifest.ManifestOptions);
+    
+    apply(compiler: Compiler): void;
 }
 
 declare namespace WebpackPwaManifest {


### PR DESCRIPTION
TypeScript is complaining when using this plugin with this error:

> Property 'apply' is missing in type 'WebpackPwaManifest' but required in type 'WebpackPluginInstance'

[html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) had this same problem and was solved with [this PR](https://github.com/jantimon/html-webpack-plugin/pull/1245).

I've mirrored that change here, and manually in my `node_modules/webpack-pwa-manifest/index.d.ts` file for testing, and it has fixed the error.